### PR TITLE
Defend against use in cycles

### DIFF
--- a/packages/tracked-redux/src/-private/tracking.ts
+++ b/packages/tracked-redux/src/-private/tracking.ts
@@ -1,6 +1,6 @@
 import {
   createStorage,
-  getValue,
+  getValue as consumeTag,
   setValue,
   TrackedStorage,
 } from 'ember-tracked-storage-polyfill';
@@ -12,7 +12,7 @@ const neverEq = (): boolean => false;
 export function createTag(): Tag {
   return createStorage(null, neverEq);
 }
-export const consumeTag = getValue;
+export { consumeTag };
 export function dirtyTag(tag: Tag): void {
   setValue(tag, null);
 }


### PR DESCRIPTION
This use of `const` is unnecessary and makes the code fragile in the case of ES module cycles.

(In case it's not clear: `let` would not be better here. The problem is the creation of a new local variable, not whether that variable is `let` vs `const`.)

Here I'm only fixing the case that we saw breaking, but in general I don't like this `export const` style because ES module import bindings are *not* the same thing as local variable bindings, and unless one enjoys keeping track of the subtle differences, it's clearer to just to use `export function` or `export { aName }` whenever possible.
